### PR TITLE
Document which yara pip package should be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 IDA pro plugin to find crypto constants (and more)
 
 ![bot](https://github.com/polymorf/findcrypt-yara/raw/master/screen.png)
+
+## Installation Notes
+If [yara](https://virustotal.github.io/yara/) is not already installed on your system, install the `yara-python` package with `pip`.
+
+**Do not** install the `yara` pip package; it is not compatible with this plugin.


### PR DESCRIPTION
Previously, it was ambiguous whether users of this plugin should use the
`yara` or `yara-python` package provided by pip. This addition to the
README makes it clear which package should be used.

This is in response to #4, where many users (including myself) had issues stemming from the fact that they installed the `yara` package instead of the `yara-python` package.