### PR TITLE
modify rename rule

### DIFF
--- a/findcrypt3.py
+++ b/findcrypt3.py
@@ -176,16 +176,24 @@ class Findcrypt_Plugin_t(idaapi.plugin_t):
         values = list()
         matches = rules.match(data=memory)
         for match in matches:
-            name = match.rule
             #print "%s => %d matches" % (name, len(match.strings))
             for string in match.strings:
                 # print "\t 0x%08x : %s" % (self.toVirtualAddress(string[0],offsets),repr(string[2]))
+                name = match.rule
+                try:
+                    if name.endswith("_API"):
+                        name = name + "_" + idc.GetString(self.toVirtualAddress(string[0], offsets))
+                except:
+                    pass
                 value = [
                     self.toVirtualAddress(string[0], offsets),
-                    name,
+                    name + "_" + hex(self.toVirtualAddress(string[0], offsets)).lstrip("0x").rstrip("L").upper(),
                     repr(string[2]),
                 ]
-                idc.set_name(value[0], name, 0)
+                idc.set_name(value[0], name
+                             + "_"
+                             + hex(self.toVirtualAddress(string[0], offsets)).lstrip("0x").rstrip("L").upper()
+                             , 0)
                 values.append(value)
         print "<<< end yara search"
         return values


### PR DESCRIPTION
1. 在标签命名后面加上当前地址，解决因标签重名而导致的命名失败；
2. 对于API规则，命名中加上API名称，之前是统一命名成了规则名，导致不能方便的看到API名；