### PR TITLE
change idc.set_name() in findcrypt3.py

### DIFF
--- a/findcrypt3.py
+++ b/findcrypt3.py
@@ -192,7 +192,7 @@ class Findcrypt_Plugin_t(idaapi.plugin_t):
                     string[1],
                     repr(string[2]),
                 ]
-                idc.set_name(value[0], name
+                idaapi.set_name(value[0], name
                              + "_"
                              + hex(self.toVirtualAddress(string[0], offsets)).lstrip("0x").rstrip("L").upper()
                              , 0)


### PR DESCRIPTION
When I ran it in my IDA pro , an error happened in line 195 of findcrypt3.py  
 ` idc.set_name(arg1,arg2,arg3,arg4)`
Error detail is that ‘module’ object has no attribute 'set_name'.
Then I read the source code of IDA\IDC, found that there is only **idaapi.py** has the function **set_name()** instead of **idc.py**.
And luckily, **findcrypt3.py** imports **idaapi.py**, so I changed **idc.set_name()** to **idaapi.set_name()**, then this plugin ran in right way. 
Wish you to update this project, and thank you for your creating and fixing it!