### PR TITLE
Add AES inverse S-Box

### DIFF
--- a/findcrypt3.rules
+++ b/findcrypt3.rules
@@ -1061,6 +1061,17 @@ rule RijnDael_AES_LONG
 		$c0
 }
 
+rule RijnDael_AES_LONG_inv
+{	meta:
+		author = "edeca"
+		description = "RijnDael AES"
+		date = "2019-10"
+	strings:
+		$c0 = { 52 09 6A D5 30 36 A5 38 BF 40 A3 9E 81 F3 D7 FB 7C E3 39 82 9B 2F FF 87 34 8E 43 44 C4 DE E9 CB }
+	condition:
+		$c0
+}
+
 rule RsaRef2_NN_modExp
 {	meta:
 		author = "Maxx"

--- a/findcrypt3.rules
+++ b/findcrypt3.rules
@@ -1072,6 +1072,17 @@ rule RijnDael_AES_LONG_inv
 		$c0
 }
 
+rule RijnDael_AES_RCON
+{	meta:
+		author = "edeca"
+		description = "RijnDael AES round constants"
+		date = "2019-10"
+	strings:
+		$c0 = { 8D 01 02 04 08 10 20 40 80 1B 36 6C D8 AB 4D 9A }
+	condition:
+		$c0
+}
+
 rule RsaRef2_NN_modExp
 {	meta:
 		author = "Maxx"


### PR DESCRIPTION
Add the inverse S-box for Rijndael, as documented at https://en.wikipedia.org/wiki/Rijndael_S-box

Found in a recent malware sample.