### PR TITLE
add rule for salsa20/chacha20

### DIFF
--- a/findcrypt3.rules
+++ b/findcrypt3.rules
@@ -1519,3 +1519,14 @@ rule Sosemanuk
     condition:
         any of them
 }
+
+rule salsa20 {
+	meta:
+		author = "eric"
+		description = "salsa20/chacha20 fixed words"
+		date = "2020-10"
+	strings:
+		$c0 = "expand 32-byte k" ascii
+	condition:
+		$c0
+}


### PR DESCRIPTION
salsa20, chacha20 use "expand 32-byte k" in their initial state. https://en.wikipedia.org/wiki/Salsa20