### PR TITLE
fix Please use "widget_type" instead of "form_type" ("form_type" is k…

### DIFF
--- a/findcrypt3.py
+++ b/findcrypt3.py
@@ -51,7 +51,7 @@ try:
 
         @classmethod
         def update(self, ctx):
-            if ctx.form_type == idaapi.BWN_DISASM:
+            if ctx.widget_type == idaapi.BWN_DISASM:
                 return idaapi.AST_ENABLE_FOR_WIDGET
             return idaapi.AST_DISABLE_FOR_WIDGET
 


### PR DESCRIPTION
…ept for backward-compatibility, and will be removed soon.)

```
findcrypt3.py", line 54, in update
    if ctx.form_type == idaapi.BWN_DISASM:
Please use "widget_type" instead of "form_type" ("form_type" is kept for backward-compatibility, and will be removed soon.)
```